### PR TITLE
Fixed Hugo REF_NOT_FOUND Error

### DIFF
--- a/content/english/pages/terms.md
+++ b/content/english/pages/terms.md
@@ -89,7 +89,7 @@ Other than the above, both You and the Collective retain all rights, titles and 
 ## Miscellaneous
 
 
-**Privacy**: The Collective is committed to protecting Your personal information and helping You understand exactly how Your personal information is being used. Please refer to our [Privacy Policy]({{< relref path="/content/english/pages/privacy-policy.md" >}}) for more details.
+**Privacy**: The Collective is committed to protecting Your personal information and helping You understand exactly how Your personal information is being used. Please refer to our [Privacy Policy]({{< ref "privacy-policy" >}}) for more details.
 
 **Entire Agreement:** These Terms constitutes the entire agreement between the Collective and You relating to the use of the Website, and supersedes all prior agreements. The Collective may enter into additional agreements with You relating to other subject matters.
 

--- a/go.mod
+++ b/go.mod
@@ -3,27 +3,26 @@ module hugoplate.netlify.app
 go 1.20
 
 require (
-	github.com/gethugothemes/hugo-modules/accordion v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/adsense v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/components/cookie-consent v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/components/custom-script v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/components/preloader v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/components/render-link v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/components/social-share v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/gallery-slider v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/gzip-caching v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/icons/font-awesome v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/images v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/modal v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/pwa v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/search v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/seo-tools/basic-seo v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/seo-tools/google-tag-manager v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/seo-tools/site-verifications v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/shortcodes/button v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/shortcodes/notice v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/tab v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/table-of-contents v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/gethugothemes/hugo-modules/videos v0.0.0-20231001043352-2e720c5b7e8b // indirect
-	github.com/zeon-studio/hugoplate v0.0.0-20230919033707-39e487943d6d // indirect
+	github.com/gethugothemes/hugo-modules/accordion v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/adsense v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/components/cookie-consent v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/components/custom-script v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/components/preloader v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/components/render-link v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/components/social-share v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/gallery-slider v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/gzip-caching v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/icons/font-awesome v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/images v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/modal v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/pwa v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/search v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/seo-tools/basic-seo v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/seo-tools/google-tag-manager v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/seo-tools/site-verifications v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/shortcodes/button v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/shortcodes/notice v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/tab v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/table-of-contents v0.0.0-20240228105219-38c9f9c6e062 // indirect
+	github.com/gethugothemes/hugo-modules/videos v0.0.0-20240228105219-38c9f9c6e062 // indirect
 )


### PR DESCRIPTION
Current relref link fails Hugo dev build. I tweaked it to a ref link that successfully builds and works on localhost.

The go.mod file automatically updated, unsure if that change is needed.